### PR TITLE
pass in external keys via initialize

### DIFF
--- a/lib/lighthouse_bgs/services.rb
+++ b/lib/lighthouse_bgs/services.rb
@@ -36,7 +36,7 @@ require 'lighthouse_bgs/services/security'
 
 module LighthouseBGS
   class Services
-    def initialize
+    def initialize(external_uid: , external_key: )
       configuration = LighthouseBGS.configuration
       @config = { env: configuration.env,
                   application: configuration.application,
@@ -49,8 +49,8 @@ module LighthouseBGS
                   forward_proxy_url: configuration.forward_proxy_url,
                   jumpbox_url: configuration.jumpbox_url,
                   log: configuration.log,
-                  external_uid: configuration.external_uid,
-                  external_key: configuration.external_key,
+                  external_uid: external_uid,
+                  external_key: external_key,
                   mock_responses: configuration.mock_responses,
                   ssl_verify_mode: configuration.ssl_verify_mode}
     end

--- a/lighthouse_bgs.gemspec
+++ b/lighthouse_bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'lighthouse_bgs'
-  gem.version       = '0.5.0'
+  gem.version       = '0.6.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,


### PR DESCRIPTION
This PR changes the initialization of the BGS service to pass the end user details for the external keys