### PR TITLE
Handle mocking for findCorporateRecord method

### DIFF
--- a/lib/lighthouse_bgs/services/vet_record.rb
+++ b/lib/lighthouse_bgs/services/vet_record.rb
@@ -47,7 +47,8 @@ module LighthouseBGS
             "firstName": first_name,
             "lastName": last_name
           }
-        }
+        },
+        "#{first_name}_#{last_name}".downcase
       )
       response.body[:find_corporate_record_response][:return]
     end


### PR DESCRIPTION
adds identifier to `find_corporate_record` method for mocking purposes