### PR TITLE
Adding find_dependents_by_participant_id

### DIFF
--- a/lib/lighthouse_bgs/services/claimant.rb
+++ b/lib/lighthouse_bgs/services/claimant.rb
@@ -40,5 +40,12 @@ module LighthouseBGS
       response = request(:find_all_relationships, 'ptcpntId': id)
       response.body[:find_all_relationships_response][:return][:dependents]
     end
+
+    # findDependentsByPtcpntId (shrinq3)
+    #   finds the dependents related to a participant ID
+    def find_dependents_by_participant_id(id, ssn)
+      response = request(:find_dependents_by_ptcpnt_id, {'ptcpntId': id}, ssn)
+      response.body[:find_dependents_by_ptcpnt_id_response][:return]
+    end
   end
 end

--- a/lighthouse_bgs.gemspec
+++ b/lighthouse_bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'lighthouse_bgs'
-  gem.version       = '0.7.0'
+  gem.version       = '0.8.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,


### PR DESCRIPTION
This PR adds the "find_dependents_by_participant_id" endpoint to the existing claimant service and updates the version in the spec to 0.8.0.

Original ticket here - https://github.com/department-of-veterans-affairs/va.gov-team/issues/5087