### PR TITLE
bump version to 0.10.0

### DIFF
--- a/lighthouse_bgs.gemspec
+++ b/lighthouse_bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'lighthouse_bgs'
-  gem.version       = '0.9.0'
+  gem.version       = '0.10.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,


### PR DESCRIPTION
This PR bumps the version of the gem. It should have been done in the host/fwd proxy change but was missed