### PR TITLE
dont use the protocol when adding the host

### DIFF
--- a/lib/lighthouse_bgs/base.rb
+++ b/lib/lighthouse_bgs/base.rb
@@ -141,7 +141,7 @@ module LighthouseBGS
         convert_request_keys_to: :none,
         ssl_verify_mode: @ssl_verify_mode.to_sym
       }
-      options[:host] = @forward_proxy_url.gsub(%r{^http://|^https://}, '') unless @forward_proxy_url.nil?
+      options[:host] = @forward_proxy_url.gsub(%r{^https?://}, '') unless @forward_proxy_url.nil?
       @client ||= Savon.client(options)
     end
 

--- a/lib/lighthouse_bgs/base.rb
+++ b/lib/lighthouse_bgs/base.rb
@@ -141,7 +141,7 @@ module LighthouseBGS
         convert_request_keys_to: :none,
         ssl_verify_mode: @ssl_verify_mode.to_sym
       }
-      options[:host] = @forward_proxy_url unless @forward_proxy_url.nil?
+      options[:host] = @forward_proxy_url.gsub(%r{^http://|^https://}, '') unless @forward_proxy_url.nil?
       @client ||= Savon.client(options)
     end
 

--- a/lighthouse_bgs.gemspec
+++ b/lighthouse_bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'lighthouse_bgs'
-  gem.version       = '0.10.0'
+  gem.version       = '0.11.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = 'Charley Stran'
   gem.email         = 'charley.stran@oddball.io'
-  gem.homepage      = ''
+  gem.homepage      = 'https://github.com/department-of-veterans-affairs/lighthouse-bgs'
 
   gem.add_runtime_dependency 'httpclient'
   gem.add_runtime_dependency 'nokogiri', '>= 1.8.5'


### PR DESCRIPTION
This PR fixes and issue the http/https protocol needs to be removed from the host parameter when setting up the savon client