### PR TITLE
Use the Savon endpoint option over savon host

### DIFF
--- a/lib/lighthouse_bgs/base.rb
+++ b/lib/lighthouse_bgs/base.rb
@@ -67,7 +67,11 @@ module LighthouseBGS
     end
 
     def wsdl
-      "#{base_url}/#{bean_name}/#{@service_name}?WSDL"
+      "#{endpoint}?WSDL"
+    end
+
+    def endpoint
+      "#{base_url}/#{bean_name}/#{@service_name}"
     end
 
     def base_url
@@ -141,7 +145,7 @@ module LighthouseBGS
         convert_request_keys_to: :none,
         ssl_verify_mode: @ssl_verify_mode.to_sym
       }
-      options[:host] = @forward_proxy_url.gsub(%r{^https?://}, '') unless @forward_proxy_url.nil?
+      options[:endpoint] = endpoint unless @forward_proxy_url.nil?
       @client ||= Savon.client(options)
     end
 

--- a/lighthouse_bgs.gemspec
+++ b/lighthouse_bgs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'lighthouse_bgs'
-  gem.version       = '0.12.1'
+  gem.version       = '0.13.0'
   gem.summary       = 'Thin wrapper on top of savon to talk with BGS'
   gem.description   = 'Thin wrapper on top of savon to talk with BGS'
   gem.license       = 'CC0' # This work is a work of the US Federal Government,


### PR DESCRIPTION
This PR changes out the use of the Savon host global to use the savon endpoint global. 